### PR TITLE
Adds in css properties to allow text to be copied from the .log-tail

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -51,6 +51,9 @@
   bottom: 0;
   overflow: auto;
 
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: text;
   background-color: rgb(40,31,44);
   color: #fff;
   word-break: break-all;


### PR DESCRIPTION
Right now, you can't copy or select text from the log, because of a `* { -webkit-user-select: none; }` line in vendor.css. This reverses that change for the `.log-tail` div, so you can more easily share stacktraces from khepri.
